### PR TITLE
Stop using the deprecated `-[UIView addConstraint:/removeConstraint:]`

### DIFF
--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -411,11 +411,7 @@ static char kInstalledConstraintsKey;
         existingConstraint.constant = layoutConstraint.constant;
         self.layoutConstraint = existingConstraint;
     } else {
-        if ([self.installedView isKindOfClass:UILayoutGuide.class]) {
-            [((UILayoutGuide *)self.installedView).owningView addConstraint:layoutConstraint];
-        } else {
-            [self.installedView addConstraint:layoutConstraint];
-        }
+        layoutConstraint.active = YES;
         
         self.layoutConstraint = layoutConstraint;
         [firstLayoutItem.mas_installedConstraints addObject:self];
@@ -449,7 +445,7 @@ static char kInstalledConstraintsKey;
         return;
     }
     
-    [self.installedView removeConstraint:self.layoutConstraint];
+    self.layoutConstraint.active = NO;
     self.layoutConstraint = nil;
     self.installedView = nil;
     


### PR DESCRIPTION
`-[UIView addConstraint:]` doesn’t work well when we add constraints between a view and a UILayoutGuide that hasn't been initialized yet (or something? in viewDidLoad) and then I noticed `addConstraint:`/`removeConstraint:` are deprecated so I replaced them.

This is the crazy code that didn’t work before and now works correctly:
![image](https://user-images.githubusercontent.com/4634735/90573229-ed836c80-e183-11ea-8192-33287145b4f7.png)